### PR TITLE
[OT276-106] Refactor en método de login

### DIFF
--- a/src/main/java/com/alkemy/ong/config/security/JwtUtils.java
+++ b/src/main/java/com/alkemy/ong/config/security/JwtUtils.java
@@ -2,11 +2,13 @@ package com.alkemy.ong.config.security;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +37,7 @@ public class JwtUtils {
     }
 
     private Claims extractAllClaims(String token) {
-        return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody();
+        return Jwts.parserBuilder().setSigningKey(getKey()).build().parseClaimsJws(token).getBody();
     }
 
     private Boolean isTokenExpired(String token) {
@@ -47,10 +49,16 @@ public class JwtUtils {
         return createToken(claims, userDetails.getUsername());
     }
 
+    private Key getKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
     private String createToken(Map<String, Object> claims, String subject) {
+
         return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY).compact();
+                .signWith(getKey()).compact();
     }
 
     public Boolean validateToken(String token, UserDetails userDetails) {


### PR DESCRIPTION
## Why is this change required?

### Motivation and Summary
## Refactorization
* Deprecated use Jwts.parserBuilder() instead. See JwtParserBuilder for usage details.
* The method signWith(SignatureAlgorithm, String) from the type JwtBuilder is deprecatedJava(67108967)

Doc -> https://github.com/jwtk/jjwt

### Type of change
- [ ] New feature
- [ ] Bug fix
- [ ] New Tests (no functional change)
- [X] Refactor (no functional change)

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
