### PR TITLE
[OT276-56] Agregar Paginación de Slides

### DIFF
--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, ApiConstants.USERS_URI).hasRole("ADMIN")
                 .antMatchers(HttpMethod.PATCH, ApiConstants.USERS_URI + "/{id}").hasAnyRole("USER", "ADMIN")
                 .antMatchers(HttpMethod.DELETE, ApiConstants.USERS_URI + "/{id}").hasAnyRole("USER", "ADMIN")
+                .antMatchers(HttpMethod.GET, ApiConstants.SLIDES_URI).hasRole("ADMIN")
                 .antMatchers(HttpMethod.GET, ApiConstants.SLIDES_URI + "/{id}").hasRole("ADMIN")
                 .antMatchers(HttpMethod.GET, ApiConstants.CATEGORIES_URI + "/{id}").hasRole("ADMIN")
                 .antMatchers(HttpMethod.GET).authenticated()

--- a/src/main/java/com/alkemy/ong/core/model/SlideList.java
+++ b/src/main/java/com/alkemy/ong/core/model/SlideList.java
@@ -1,0 +1,12 @@
+package com.alkemy.ong.core.model;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class SlideList extends PageImpl<Slide> {
+    public SlideList(List<Slide> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+}

--- a/src/main/java/com/alkemy/ong/core/usecase/SlideService.java
+++ b/src/main/java/com/alkemy/ong/core/usecase/SlideService.java
@@ -1,6 +1,8 @@
 package com.alkemy.ong.core.usecase;
 
 import com.alkemy.ong.core.model.Slide;
+import com.alkemy.ong.core.model.SlideList;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -11,4 +13,6 @@ public interface SlideService {
     List<Slide> getListByOrganizationIdAndOrderByOrder(Long id);
 
     long createEntity(String imageBase64, Integer order, String text, Long organizationId);
+
+    SlideList getList(PageRequest pageRequest);
 }

--- a/src/main/java/com/alkemy/ong/core/usecase/impl/SlideServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/core/usecase/impl/SlideServiceImpl.java
@@ -3,11 +3,14 @@ package com.alkemy.ong.core.usecase.impl;
 import com.alkemy.ong.config.exception.NotFoundException;
 import com.alkemy.ong.core.model.Organization;
 import com.alkemy.ong.core.model.Slide;
+import com.alkemy.ong.core.model.SlideList;
 import com.alkemy.ong.core.repository.OrganizationRepository;
 import com.alkemy.ong.core.repository.SlideRepository;
 import com.alkemy.ong.core.usecase.SlideService;
 import com.alkemy.ong.ports.output.s3.S3ServiceImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,6 +64,13 @@ public class SlideServiceImpl implements SlideService {
 
 
         return slideRepository.save(slide).getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SlideList getList(PageRequest pageRequest) {
+        Page<Slide> page = slideRepository.findAll(pageRequest);
+        return new SlideList(page.getContent(), pageRequest, page.getTotalElements());
     }
 
 }

--- a/src/main/java/com/alkemy/ong/ports/input/rs/controller/SlideController.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/controller/SlideController.java
@@ -1,18 +1,24 @@
 package com.alkemy.ong.ports.input.rs.controller;
 
 import com.alkemy.ong.core.model.Slide;
+import com.alkemy.ong.core.model.SlideList;
 import com.alkemy.ong.core.usecase.SlideService;
+import com.alkemy.ong.ports.input.rs.api.ApiConstants;
 import com.alkemy.ong.ports.input.rs.api.SlideApi;
 import com.alkemy.ong.ports.input.rs.mapper.SlideControllerMapper;
 import com.alkemy.ong.ports.input.rs.request.SlideRequest;
 import com.alkemy.ong.ports.input.rs.response.SlideResponse;
+import com.alkemy.ong.ports.input.rs.response.SlideResponseList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.util.List;
+import java.util.Optional;
 
 import static com.alkemy.ong.ports.input.rs.api.ApiConstants.SLIDES_URI;
 
@@ -33,6 +39,33 @@ public class SlideController implements SlideApi {
         return ResponseEntity.ok(slideResponse);
     }
 
+    @GetMapping
+    public ResponseEntity<SlideResponseList> getSlide(@RequestParam Optional<Integer> page,
+                                                      @RequestParam Optional<Integer> size) {
+
+        final int pageNumber = page.filter(p -> p > 0).orElse(ApiConstants.DEFAULT_PAGE);
+        final int pageSize = size.filter(s -> s > 0).orElse(ApiConstants.DEFAULT_PAGE_SIZE);
+
+        SlideList list = slideService.getList(PageRequest.of(pageNumber, pageSize));
+
+        SlideResponseList response;
+        {
+            response = new SlideResponseList();
+
+            List<SlideResponse> content = mapper.slideListToSlideResponseList(list.getContent());
+            response.setContent(content);
+
+            final int nextPage = list.getPageable().next().getPageNumber();
+            response.setNextUri(ApiConstants.uriByPageAsString.apply(nextPage));
+
+            final int previousPage = list.getPageable().previousOrFirst().getPageNumber();
+            response.setPreviousUri(ApiConstants.uriByPageAsString.apply(previousPage));
+
+            response.setTotalPages(list.getTotalPages());
+            response.setTotalElements(list.getTotalElements());
+        }
+        return ResponseEntity.ok().body(response);
+    }
 
     @Override
     @PostMapping

--- a/src/main/java/com/alkemy/ong/ports/input/rs/response/SlideResponseList.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/response/SlideResponseList.java
@@ -1,0 +1,23 @@
+package com.alkemy.ong.ports.input.rs.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SlideResponseList {
+    private List<SlideResponse> content = null;
+    @JsonProperty("next_uri")
+    private String nextUri;
+    @JsonProperty("previous_uri")
+    private String previousUri;
+    @JsonProperty("total_pages")
+    private Integer totalPages;
+    @JsonProperty("total_elements")
+    private Long totalElements;
+}


### PR DESCRIPTION
## Why is this change required?

### Motivation and Summary
COMO usuario administrador
QUIERO visualizar los resultados de Slides paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page

Criterios de aceptación:

Se debe hacer una petición GET a /Slides. 

Devolverá el listado de Slides, con la imagen y el orden del mismo

### Type of change
- [x] New feature
- [ ] Bug fix
- [ ] New Tests (no functional change)
- [ ] Refactor (no functional change)

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
